### PR TITLE
Update Spec to include ServerToAgentCommand

### DIFF
--- a/specification.md
+++ b/specification.md
@@ -248,6 +248,7 @@ message ServerToAgent {
     AgentPackageAvailable agent_package_available = 6;
     Flags flags = 7;
     ServerCapabilities capabilities = 8;
+    ServerCommand command = 9
 }
 ```
 
@@ -352,9 +353,33 @@ enum ServerCapabilities {
     AcceptsAgentPackageStatus      = 0x00000040;
     // The Server can offer connection settings.
     OffersConnectionSettings       = 0x00000080;
+    // The Agent can accept restart requests.
+    AcceptsRestartRequests         = 0x00001000;
+    // The Agent can accept shutdown requests.
+    AcceptsShutdownRequests        = 0x00002000;
 
     // Add new capabilities here, continuing with the least significant unused bit.
 }
+```
+
+#### command
+
+Defined by CommandType enum. This field is set when the server wants the agent to
+perform a restart or shutdown command. This field must not be set with other fields
+besides instance_uid or capabilities. All other fields will be ignored and the
+agent will execute the command.
+
+```protobuf
+enum CommandType {
+    // The agent should restart. This request will be ignored if the agent does not
+    // support restart.
+    Restart = 0;
+
+    // The agent should shutdown. This request will be ignored if the agent does not
+    // support shutdown. Shutdown is permanent and the agent will no longer be running
+    // or connected to the management server.
+    Shutdown = 1;
+    }
 ```
 
 

--- a/specification.md
+++ b/specification.md
@@ -248,7 +248,7 @@ message ServerToAgent {
     AgentPackageAvailable agent_package_available = 6;
     Flags flags = 7;
     ServerCapabilities capabilities = 8;
-    ServerCommand command = 9
+    ServerToAgentCommand command = 9
 }
 ```
 
@@ -366,15 +366,20 @@ besides instance_uid or capabilities. All other fields will be ignored and the
 agent will execute the command.
 
 ```protobuf
-enum CommandType {
-    // The agent should restart. This request will be ignored if the agent does not
-    // support restart.
-    Restart = 0;
+// ServerToAgentCommand is sent from the server to the agent to request that the agent
+// perform a command.
+message ServerToAgentCommand {
+    enum CommandType {
+        // The agent should restart. This request will be ignored if the agent does not
+        // support restart.
+        Restart = 0;
 
-    // The agent should shutdown. This request will be ignored if the agent does not
-    // support shutdown. Shutdown is permanent and the agent will no longer be running
-    // or connected to the management server.
-    Shutdown = 1;
+        // The agent should shutdown. This request will be ignored if the agent does not
+        // support shutdown. Shutdown is permanent and the agent will no longer be running
+        // or connected to the management server.
+        Shutdown = 1;
+    }
+    CommandType type = 1;
 }
 ```
 

--- a/specification.md
+++ b/specification.md
@@ -353,10 +353,6 @@ enum ServerCapabilities {
     AcceptsAgentPackageStatus      = 0x00000040;
     // The Server can offer connection settings.
     OffersConnectionSettings       = 0x00000080;
-    // The Agent can accept restart requests.
-    AcceptsRestartRequests         = 0x00001000;
-    // The Agent can accept shutdown requests.
-    AcceptsShutdownRequests        = 0x00002000;
 
     // Add new capabilities here, continuing with the least significant unused bit.
 }
@@ -379,7 +375,7 @@ enum CommandType {
     // support shutdown. Shutdown is permanent and the agent will no longer be running
     // or connected to the management server.
     Shutdown = 1;
-    }
+}
 ```
 
 
@@ -644,6 +640,10 @@ enum AgentCapabilities {
     // The can accept connections settings for other destinations via
     // ConnectionSettingsOffers.other_connections field.
     AcceptsOtherConnectionSettings = 0x00000800;
+    // The Agent can accept restart requests.
+    AcceptsRestartRequests         = 0x00001000;
+    // The Agent can accept shutdown requests.
+    AcceptsShutdownRequests        = 0x00002000;
 
     // Add new capabilities here, continuing with the least significant unused bit.
 }
@@ -2448,7 +2448,7 @@ TBD
 * Do we need to define OpenTelemetry semantic conventions for reporting typical
   collection Agent-specific metrics (e.g. input/processing/output data rates,
   throughput, latency, etc)?
-* Do we need a capability for the Server to order the Agent to restart?
+* ~~Do we need a capability for the Server to order the Agent to restart?~~ Added.
 * Do we need Agent-initiated client certificate rotation capability (in addition
   to Server-initiated that we already have)?
 * Do we need to recommend the Agent to cache the remote config and OTLP metric

--- a/specification.md
+++ b/specification.md
@@ -360,7 +360,7 @@ enum ServerCapabilities {
 
 #### command
 
-Defined by CommandType enum. This field is set when the server wants the agent to
+This field is set when the server wants the agent to
 perform a restart or shutdown command. This field must not be set with other fields
 besides instance_uid or capabilities. All other fields will be ignored and the
 agent will execute the command.


### PR DESCRIPTION
Documents the changes proposed in https://github.com/open-telemetry/opamp-go/pull/53.

- `ServerToAgent` message now can contain `ServerToAgentCommand`
- Documented `ServerToAgentCommand` message.
- Resolved an open question, The PR would add capability for the server to order an Agent to restart.